### PR TITLE
Inprogress

### DIFF
--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -16,8 +16,14 @@ const sequelize = process.env.DB_URL
         dialect: "postgres",
         dialectOptions: {
           decimalNumbers: true,
+          /* Use SSL if required:
+             Render's initial db doesn't require ssl, but
+             if you want to isolate the app in a separate
+             database, ssl is required */
           ssl: {
+            // forces attempt to connect using ssl when required (for production)
             require: true,
+            // allow self-signed cert for local testing, but should be improved for security!
             rejectUnauthorized: false,
           },
         },

--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -1,24 +1,33 @@
-import dotenv from 'dotenv';
+import dotenv from "dotenv";
 dotenv.config();
 
-import { Sequelize } from 'sequelize';
-import { UserFactory } from './user.js';
-import { TicketFactory } from './ticket.js';
+import { Sequelize } from "sequelize";
+import { UserFactory } from "./user.js";
+import { TicketFactory } from "./ticket.js";
 
 const sequelize = process.env.DB_URL
   ? new Sequelize(process.env.DB_URL)
-  : new Sequelize(process.env.DB_NAME || '', process.env.DB_USER || '', process.env.DB_PASSWORD, {
-      host: 'localhost',
-      dialect: 'postgres',
-      dialectOptions: {
-        decimalNumbers: true,
-      },
-    });
+  : new Sequelize(
+      process.env.DB_NAME || "",
+      process.env.DB_USER || "",
+      process.env.DB_PASSWORD,
+      {
+        host: "localhost",
+        dialect: "postgres",
+        dialectOptions: {
+          decimalNumbers: true,
+          ssl: {
+            require: true,
+            rejectUnauthorized: false,
+          },
+        },
+      }
+    );
 
 const User = UserFactory(sequelize);
 const Ticket = TicketFactory(sequelize);
 
-User.hasMany(Ticket, { foreignKey: 'assignedUserId' });
-Ticket.belongsTo(User, { foreignKey: 'assignedUserId', as: 'assignedUser'});
+User.hasMany(Ticket, { foreignKey: "assignedUserId" });
+Ticket.belongsTo(User, { foreignKey: "assignedUserId", as: "assignedUser" });
 
 export { sequelize, User, Ticket };


### PR DESCRIPTION
Multiple apps were sharing the same database on the production deployment server leading to credential conflicts
- Isolating the app to its own database reveled that render only supports non-ssl connections for the server's initial database, not any new ones
- Added an SSL check to the Sequelize connection to support connecting with or without ssl so that it will work using either the initial database or an isolated one.