### PR TITLE
Support Render Blueprint deployments for DB replacement

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,11 @@
+services:
+  - type: web
+    name: InYourLane
+    env: node
+    branch: main
+    buildCommand: npm install && npm run build
+    startCommand: npm start
+    envVars:
+      - key: DB_URL
+        value: "postgresql://render_deploy_42b8_user:YOUR_PASSWORD@YOUR_HOST/YOUR_DATABASE"
+        sync: false

--- a/render.yaml
+++ b/render.yaml
@@ -2,10 +2,9 @@ services:
   - type: web
     name: InYourLane
     env: node
-    branch: main
-    buildCommand: npm install && npm run build
+    branch: inprogress
+    buildCommand: npm run render-seed
     startCommand: npm start
     envVars:
       - key: DB_URL
-        value: "postgresql://render_deploy_42b8_user:YOUR_PASSWORD@YOUR_HOST/YOUR_DATABASE"
         sync: false


### PR DESCRIPTION
The Render free-tier postgres deployment expires after 30d. This is a quick way to handle deploying to a fresh postgres instance